### PR TITLE
Support modules

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   componentWillMount: function () {
     this.signals = this.context.controller.signals;
+    this.modules = this.context.controller.modules;
 
     if (!this.getStatePaths) {
       return;

--- a/src/render.js
+++ b/src/render.js
@@ -16,6 +16,7 @@ module.exports = function (Component) {
     }, propsToPass);
 
     propsToPass.signals = this.signals;
+    propsToPass.modules = this.modules;
     propsToPass.get = this.get; // Uhm?
 
     return React.createElement(Component, propsToPass);


### PR DESCRIPTION
Companion to https://github.com/cerebral/cerebral/pull/149

enables the following:

``` js
@Cerebral({
})
export default class Application extends Component {
  static propTypes = {
    modules: PropTypes.object,
    signals: PropTypes.object
  };

  render() {
    const Home = this.props.modules.home.Component;

    return (
      <Home/>
    );
  }
}
```
