### PR TITLE
fixes issue when router is not root-level module

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,5 @@
     "analyzeCommits": "./sr-prerelease.js"
   },
   "dependencies": {
-    "lodash.get": "^4.0.0"
   }
 }

--- a/src/link.js
+++ b/src/link.js
@@ -1,5 +1,4 @@
 var React = require('react')
-var get = require('lodash.get')
 
 module.exports = React.createClass({
   contextTypes: {
@@ -34,12 +33,12 @@ module.exports = React.createClass({
       signalName = signal.signalName
     } else {
       signalName = this.props.signal
-      signal = this.signal = get(controller.getSignals(), signalName)
+      signal = this.signal = controller.getSignals(signalName)
     }
 
     var routerMeta = controller.getModules()['cerebral-module-router']
     if (routerMeta) {
-      router = get(controller.getServices(), routerMeta.path)
+      router = controller.getServices(routerMeta.path)
     }
 
     if (typeof signal !== 'function') {

--- a/src/link.js
+++ b/src/link.js
@@ -39,7 +39,7 @@ module.exports = React.createClass({
 
     var routerMeta = controller.getModules()['cerebral-module-router']
     if (routerMeta) {
-      router = get(controller.getServices(), routerMeta.name)
+      router = get(controller.getServices(), routerMeta.path)
     }
 
     if (typeof signal !== 'function') {


### PR DESCRIPTION
When router is not at root level, then the `href` prop breaks. `Link` should use `module.path` and not `module.name` to locate `cerebral-module-router`
