### PR TITLE
fix(debugger): pass initial components registered on mount

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -27,10 +27,13 @@ module.exports = React.createClass({
   componentWillMount: function () {
     this.props.controller.on('flush', this.onCerebralUpdate)
   },
+  componentDidMount: function () {
+    this.onCerebralUpdate({}, true)
+  },
   extractComponentName: function (component) {
     return component.constructor.displayName.replace('CerebralWrapping_', '')
   },
-  onCerebralUpdate: function (changes) {
+  onCerebralUpdate: function (changes, force) {
     var componentsMap = this.componentsMap
     function traverse (level, currentPath, componentsToRender) {
       Object.keys(level).forEach(function (key) {
@@ -58,7 +61,7 @@ module.exports = React.createClass({
     })
     var end = Date.now()
 
-    if (window && process.env.NODE_ENV !== 'production' && componentsToRender.length) {
+    if (window && process.env.NODE_ENV !== 'production' && (componentsToRender.length || force)) {
       var container = this
       var devtoolsComponentsMap = Object.keys(componentsMap).reduce(function (devtoolsComponentsMap, key) {
         devtoolsComponentsMap[key] = componentsMap[key].map(container.extractComponentName)


### PR DESCRIPTION
This fixes an issue where debugger does not get info about initial render
