### PR TITLE
fix(eventListener): should listen to flush event on mount, not willmount

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -24,11 +24,9 @@ module.exports = React.createClass({
   componentsMap: {},
   overlays: {},
   overlaysContainer: null,
-  componentWillMount: function () {
-    this.props.controller.on('flush', this.onCerebralUpdate)
-  },
   componentDidMount: function () {
     this.onCerebralUpdate({}, true)
+    this.props.controller.on('flush', this.onCerebralUpdate)
   },
   extractComponentName: function (component) {
     return component.constructor.displayName.replace('CerebralWrapping_', '')


### PR DESCRIPTION
We can not listen to "flush" on `componentWillMount` due to that also triggers on the server. Moved it to `componentDidMount`.

This should not cause any problems, as an `immediate` trigger of signals with previous position of listener would cause an error. Should not start updating the app before things are mounted.
