### PR TITLE
Update cleanPath.js to match cerebral

### DIFF
--- a/src/cleanPath.js
+++ b/src/cleanPath.js
@@ -1,4 +1,8 @@
 function cleanPath (path) {
+  if (Array.isArray(path)) {
+    path = path.join('.')
+  }
+
   return path.replace(/\.\*\*|\.\*/, '')
 }
 


### PR DESCRIPTION
Without it, the old ['path', 'to', 'something'] will break.
